### PR TITLE
Edited code completion contents for dd_tilde

### DIFF
--- a/markdown.sublime-completions
+++ b/markdown.sublime-completions
@@ -8,7 +8,7 @@
 		{ "trigger": "dd_version", "contents": "<<dd_version: ${1:number} >>" },
 		{ "trigger": "dd_display", "contents": "<<dd_display: `${1: }'  >>" },
 		{ "trigger": "dd_display_number", "contents": "<<dd_display: %4.2f `${1:number}'>>" },
-		{ "trigger": "dd_tilde", "contents": "~~~~\n" },
+		{ "trigger": "dd_tilde", "contents": "~~~~\n${1:}\n~~~~\n" },
 		{ "trigger": "dd_do", "contents": "<<dd_do>>\n${1:Stata_commands}\n<</dd_do>>\n" },
 		{ "trigger": "dd_ignore", "contents": "<<dd_ignore>>\n${1:}\n<</dd_ignore>>\n" }
 	]


### PR DESCRIPTION
Edited code completion to make the delimiter tildes appears twice separated by a blank line. Code blocks always require a pair of delimiter tildes-- hence makes sense to output a pair of delimiter tildes rather than only one.