### PR TITLE
Change package config directories

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -32,14 +32,14 @@
                             {
                                 "command": "open_file",
                                 "args": {
-                                    "file": "${packages}/MacStataEditor/MacStataEditor (OSX).sublime-settings",
+                                    "file": "${packages}/Stata Improved Editor/StataImproved (OSX).sublime-settings",
                                     "platform": "OSX"
                                 },
                                 "caption": "Settings – Default"
                             }, 
                             {
                                 "command": "open_file",
-                                "args": {"file": "${packages}/User/MacStataEditor.sublime-settings"},
+                                "args": {"file": "${packages}/User/StataImproved (OSX).sublime-settings"},
                                 "caption": "Settings – User"
                             },
                             {
@@ -50,7 +50,7 @@
                             {
                                 "command": "open_file",
                                 "args": {
-                                    "file": "${packages}/MacStataEditor/Default (OSX).sublime-keymap",
+                                    "file": "${packages}/Stata Improved Editor/Default (OSX).sublime-keymap",
                                     "platform": "OSX"
                                 },
                                 "caption": "Key Bindings – Default"

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ If you could not find the package control in your ST3, you will need to install 
 Note that though the trial version of the ST3 is untimed and unlimited, the license need be purchased. 
 
 ### Manual installation
-Open the ST3, click the Preferences-> Browse Packages-> Then you will reach the folder `~/Library/Application Support/Sublime Text 3/Packages`. Download [this Stata plugin from here](https://github.com/zizhongyan/StataImproved/archive/master.zip), and unpack the zip fil into that folder, and rename it as "StataImproved". 
+Open the ST3, click the Preferences-> Browse Packages-> Then you will reach the folder `~/Library/Application Support/Sublime Text 3/Packages`. Download [this Stata plugin from here](https://github.com/zizhongyan/StataImproved/archive/master.zip), and unpack the zip fil into that folder, and rename it as "Stata Improved Editor". 
 
 
 


### PR DESCRIPTION
The preferred name for this package, and by extension its hard-coded installation path, appears to be "Stata Improved Editor" rather than "MacStataEditor". Since this is how Package Control installs the package directory hooks for the config and keymap files, the config menus and defaults are broken when installed since they point to a non-existent directory. Diagnosing this is somewhat mysterious to a new ST user.

Since the preferred installation language seems to be "Stata Improved Editor," I changed package config directories from "MacStataEditor" to "Stata Improved Editor" in order to properly harmonize with Package Control distribution. Your preference may actually be to change the naming convention in Package Control, but then the Readme instructions for manual installation should probably harmonized to that.