### PR TITLE
[WIP] Initial support for variable auto-completion

### DIFF
--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -3,6 +3,9 @@
     "keys": ["ctrl+d"], "command": "lines_to_stata"
   },
   {
+    "keys": ["ctrl+z"], "command": "refresh_var"
+  },
+  {
     "keys": ["ctrl+r"], "command": "lines_stata_run"
   },
   { "keys": ["f1"], "command": "stata_help", "context":

--- a/StataImproved.py
+++ b/StataImproved.py
@@ -198,7 +198,7 @@ class StataVarCompletionsListener(sublime_plugin.EventListener):
 			return
 		version, stata_app_id = get_stata_version()
 		export_cmd = 'qui export delimited using "/tmp/stata_vars.csv" in 1, replace'
-		stata_run(export_cmd)
+		stata_run(export_cmd, quiet=True, comment="Auto-complete")
 		tries = 0
 		while True:
 			try:
@@ -213,7 +213,13 @@ class StataVarCompletionsListener(sublime_plugin.EventListener):
 		completions = [(v + "\tStata Var", v) for v in stata_vars if prefix in v]
 		return completions
 
-def stata_run(line):
+def stata_run(line, quiet=False, comment=""):
+	if quiet:
+		qui = "qui "
+	else:
+		qui = ""
+	if comment:
+		comment = "// " + comment
 	selectedcode = line + "\n"
 	dofile_path =tempfile.gettempdir()+'selectedlines_piupiu.do'
 	with codecs.open(dofile_path, 'w', encoding='utf-8') as out:  
@@ -221,9 +227,9 @@ def stata_run(line):
 	version, stata_app_id = get_stata_version()
 	cmd = """osascript<< END
 	 tell application id "{0}"
-	    DoCommandAsync "do {1}"  with addToReview
+	    DoCommandAsync "{1}do {2} {3}"  with addToReview
 	 end tell
-	 END""".format(stata_app_id, dofile_path) 
+	 END""".format(stata_app_id, qui, dofile_path, comment)
 	print(cmd)
 	print("stata_app_id")
 	print(stata_app_id)

--- a/StataImproved.py
+++ b/StataImproved.py
@@ -112,7 +112,7 @@ class PiuSign(sublime_plugin.TextCommand):
 		 END""".format(stata_app_id,dofile_path,"Viewer") 
 		os.system(cmd) 
 class lines_to_stataCommand(sublime_plugin.TextCommand): 
-	def run(self, edit): 
+	def run(self, edit):
 		selectedcode = ""
 		sels = self.view.sel()
 		for sel in sels:
@@ -192,13 +192,11 @@ class LinesStataRun(sublime_plugin.TextCommand):
 		print("stata_app_id")
 		print(stata_app_id)
 		os.system(cmd)
+
 class StataVarCompletionsListener(sublime_plugin.EventListener):
 	def on_query_completions(self, view, prefix, locations):
 		if not view.score_selector(locations[0], "source.stata"):
 			return
-		version, stata_app_id = get_stata_version()
-		export_cmd = 'qui export delimited using "/tmp/stata_vars.csv" in 1, replace'
-		stata_run(export_cmd, quiet=True, comment="Auto-complete")
 		tries = 0
 		while True:
 			try:
@@ -206,12 +204,21 @@ class StataVarCompletionsListener(sublime_plugin.EventListener):
 					stata_vars = f.readline().strip().split(',')
 					break
 			except FileNotFoundError:
+				refresh_var()
 				time.sleep(0.3)
 				tries += 1
 				if tries > 5:
 					break
 		completions = [(v + "\tStata Var", v) for v in stata_vars if prefix in v]
 		return completions
+
+class RefreshVarCommand(sublime_plugin.TextCommand):
+    def run(self, edit):
+        refresh_var()
+
+def refresh_var():
+	export_cmd = 'qui export delimited using "/tmp/stata_vars.csv" in 1, replace'
+	stata_run(export_cmd, quiet=True, comment="Auto-complete")
 
 def stata_run(line, quiet=False, comment=""):
 	if quiet:

--- a/StataImproved.py
+++ b/StataImproved.py
@@ -194,6 +194,8 @@ class LinesStataRun(sublime_plugin.TextCommand):
 		os.system(cmd)
 class StataVarCompletionsListener(sublime_plugin.EventListener):
 	def on_query_completions(self, view, prefix, locations):
+		if not view.score_selector(locations[0], "source.stata"):
+			return
 		version, stata_app_id = get_stata_version()
 		export_cmd = 'qui export delimited using "/tmp/stata_vars.csv" in 1, replace'
 		stata_run(export_cmd)
@@ -221,7 +223,7 @@ def stata_run(line):
 	 tell application id "{0}"
 	    DoCommandAsync "do {1}"  with addToReview
 	 end tell
-	 END""".format(stata_app_id,dofile_path) 
+	 END""".format(stata_app_id, dofile_path) 
 	print(cmd)
 	print("stata_app_id")
 	print(stata_app_id)


### PR DESCRIPTION
Hey guys,

I included a small hack in this pull request to support Stata variable name auto-completion in Sublime Text. This plugin will query all variables upon the first user's auto-completion trigger. The user will need to manually refresh the variables by pressing `ctrl + z`.

The only side-effect is that the query will leave a line of output on your Stata console. It seems that there is no workaround for now, but I will keep an eye on it.

Hope it helps. 